### PR TITLE
feat: clicking a filter header on resources page closes/opens the corresponding filter panel

### DIFF
--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -32,7 +32,7 @@ for (let p of params) {
 }
 
 let isStaticViewVisible = true;
-  
+
 /*
  * Set up aside menu by:
  * 1. populate content with headings sourced from given selectors;
@@ -94,16 +94,16 @@ new Vue({
 				};
 
 				results = filterResources(results, filterSettings);
-				
+
 				// Convert some post values to formats that can be displayed
 				if (results.length > 0) {
 					results = processResourcesDisplayResults(results);
 				}
-				
+
 				let tagsQuery = selectedTags.map(tag => "t_" + tag).join("=on&") +
 					selectedCategories.map(cat => "c_" + cat).join("=on&") +
 					selectedTypes.map(type => "t_" + type).join("=on&") + "=on";
-				
+
 				// Paginate search results
 				if (results.length > pageSize) {
 					pagination = createPagination(results, pageSize, pageInQuery, "/resources/?s=" + searchTerm + "&" + tagsQuery + "&page=:page");
@@ -113,7 +113,7 @@ new Vue({
 				vm.tags = response.data.tags.map(tag => ({ ...tag, checked: selectedTags.includes(tag.value)}));
 				vm.resourceCategories = response.data.resourceCategories.map(cat => ({ ...cat, checked: includesCaseInsensitive(selectedCategories, cat.categoryId)}));
 				vm.resourceTypes = response.data.resourceTypes.map(type => ({ ...type, checked: includesCaseInsensitive(selectedTypes, type.value)}));
-				
+
 				vm.selectedTags = response.data.tags.filter(tag => selectedTags.includes(tag.value));
 				vm.pagination = pagination;
 				vm.resultsToDisplay = pagination ? pagination.items : results;
@@ -156,6 +156,7 @@ for (let i = 0; i < expandButtons.length; i++) {
 	// Add event listener for expand buttons
 	expandButtons[i].addEventListener("click", (e) => {
 		e.preventDefault();
+		e.stopPropagation();
 		const currentExpandedValue = expandButtons[i].getAttribute("aria-expanded");
 		const expandedState = currentExpandedValue === "true" ? "false" : "true";
 		expandButtons[i].setAttribute("aria-expanded", expandedState);
@@ -171,6 +172,16 @@ for (let i = 0; i < expandButtons.length; i++) {
 
 		// Show/hide the expand svg
 		setExpandSVGState(expandButtons[i], expandedState);
+	});
+}
+
+// clicking a filter header opens/closes the corresponding filter. It behaves the same as clicking the corresponding
+// expand/collapse button.
+const filterHeaders = document.querySelectorAll(".filter .filter-header");
+
+for (let i = 0; i < filterHeaders.length; i++) {
+	filterHeaders[i].addEventListener("click", () => {
+		$(filterHeaders[i]).find(".filter-expand-button").click();
 	});
 }
 

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -68,6 +68,13 @@
 			background-color: initial;
 			border-bottom: rem(1) solid $grey-mid-light;
 			margin: 0;
+			padding: 0 rem(16);
+
+			&:focus,
+			&:hover {
+				border-radius: rem(8);
+				box-shadow: 0 0 rem(12) rgba(0, 0, 0, 0.6);
+			}
 
 			button {
 				margin-right: 0;

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -70,10 +70,8 @@
 			margin: 0;
 			padding: 0 rem(16);
 
-			&:focus,
 			&:hover {
-				border-radius: rem(8);
-				box-shadow: 0 0 rem(12) rgba(0, 0, 0, 0.6);
+				box-shadow: 0 rem(3) rem(2) rem(-2) rgba(0, 0, 0, 0.6);
 			}
 
 			button {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Clicking a filter header on resources page closes/opens the pane.

## Steps to test

1. Go to the resources page;
2. Hover on one filter header, hover style should be applied to the header;
3. Click the header, the corresponding filter panel should open/close with each click;
4. Click the expand/collapse button in the header. Make sure it behaves correctly.

**Expected behavior:** 
See above.