### PR TITLE
feat: add counter for selected filter choices

### DIFF
--- a/src/_includes/components/filter-resources.njk
+++ b/src/_includes/components/filter-resources.njk
@@ -3,7 +3,7 @@
   {# Topic selections #}
   {# TODO: Dedupe this control #}
   <div class="filter-header">
-    <h3>{{ topicsFilterTitle }}</h3>
+    <h3>{{ topicsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">0</span>)</h3>
     <button type="button" class="filter-expand-button" data-section="topics" aria-expanded="false" aria-label="expand">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
@@ -44,7 +44,7 @@
   {# Tag selections #}
   {# TODO: Dedupe this control #}
   <div class="filter-header">
-    <h3>{{ tagsFilterTitle }}</h3>
+    <h3>{{ tagsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">0</span>)</h3>
     <button type="button" class="filter-expand-button" data-section="tags" aria-expanded="false" aria-label="expand">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
@@ -66,7 +66,7 @@
   {# Media Type selections #}
   {# TODO: Dedupe this control #}
   <div class="filter-header">
-    <h3>{{ typeFilterTitle }}</h3>
+    <h3>{{ typeFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">0</span>)</h3>
     <button type="button" class="filter-expand-button" data-section="types" aria-expanded="false" aria-label="expand">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>

--- a/src/_includes/components/filter-resources.njk
+++ b/src/_includes/components/filter-resources.njk
@@ -56,7 +56,7 @@
       {% for tag in resourceTags.resourceTags  %}
         {% set tagId = tag.value | randomizeFilter %}
         <li>
-          <input class="filter-checkbox" type="checkbox" id="{{ tagId }}" name="{{ 't_' + tag.value | slug }}">
+          <input class="filter-checkbox" type="checkbox" id="{{ tagId }}" name="{{ 't_' + tag.value }}">
           <label for="{{ tagId }}">{{ tag.label }}</label>
         </li>
       {% endfor %}

--- a/src/_includes/layouts/resources.njk
+++ b/src/_includes/layouts/resources.njk
@@ -109,7 +109,7 @@ pagination:
         {# Topic selections #}
         {# TODO: Dedupe this control #}
         <div class="filter-header">
-          <h3>{{ topicsFilterTitle }}</h3>
+          <h3>{{ topicsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedCategories.length }}' }}</span>)</h3>
           <button type="button" class="filter-expand-button" data-section="topics" aria-expanded="true" aria-label="expand">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
@@ -128,7 +128,7 @@ pagination:
         {# Tag selections #}
         {# TODO: Dedupe this control #}
         <div class="filter-header">
-          <h3>{{ tagsFilterTitle }}</h3>
+          <h3>{{ tagsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedTags.length }}' }}</span>)</h3>
           <button type="button" class="filter-expand-button" data-section="tags" aria-expanded="true" aria-label="expand">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
@@ -147,7 +147,7 @@ pagination:
         {# Media Type selections #}
         {# TODO: Dedupe this control #}
         <div class="filter-header">
-          <h3>{{ typeFilterTitle }}</h3>
+          <h3>{{ typeFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedTypes.length }}' }}</span>)</h3>
           <button type="button" class="filter-expand-button" data-section="types" aria-expanded="true" aria-label="expand">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
@@ -201,7 +201,7 @@ pagination:
                 </li>
               </ul>
             </div>
-            
+
             <div class="info">
               <svg aria-hidden="true" tabindex="0"><use xlink:href="#topics" /></svg>
               Topic: {{ '{{ resourceCategories.filter(cat => cat.focuses.includes(item.focus))[0].categoryLabel }}' }}

--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -49,6 +49,24 @@ function setupAside(selectors) {
 	});
 }
 
+/*
+ * Bind change events for filter choice checkboxes. When a choice is checked or unchecked, update the selected
+ * choices counter on the filter header.
+ * @param {String} viewSelector - The selector of the static or the dynamic view template
+ */
+function bindChoiceChange(viewSelector) {
+	// Clicking filter choices updates the corresponding counter
+	const filterCheckboxes = document.querySelectorAll(viewSelector + " .filter .filter-checkbox");
+
+	for (let i = 0; i < filterCheckboxes.length; i++) {
+		filterCheckboxes[i].addEventListener("change", (e) => {
+			const counterElm = $(e.target.closest(".filter-body")).prev().find(".filter-selected-choice-counter")[0];
+			const currentCount = parseInt(counterElm.innerText);
+			counterElm.innerText = e.target.checked ? currentCount + 1 : currentCount - 1;
+		});
+	}
+}
+
 new Vue({
 	el: "#defaultContainer",
 	data: {
@@ -59,7 +77,8 @@ new Vue({
 		pagination: null,
 		resourceCategories: [],
 		resourceReadabilityLevels: [],
-		resourceTypes: []
+		resourceTypes: [],
+		numOfUpdated: 0
 	},
 	mounted() {
 		let vm = this;
@@ -125,6 +144,12 @@ new Vue({
 		// Re-setup the <aside> section when filter/search results are rendered
 		document.querySelector("aside#toc").innerHTML="";
 		setupAside("main article.dynamic-view h1, main article.dynamic-view h2");
+
+		// Make sure change events for choice checkboxes in the dynamic view only bind once
+		if (this.numOfUpdated === 0) {
+			bindChoiceChange(".dynamic-view");
+			this.numOfUpdated = 1;
+		}
 	}
 });
 
@@ -132,6 +157,9 @@ new Vue({
 if (isStaticViewVisible) {
 	setupAside("main article.static-view h1, main article.static-view h2");
 }
+
+// Bind change events for all choice checkboxes in the static view template
+bindChoiceChange(".static-view");
 
 /*
  * Show/hide the corresponding arrow up and down buttons based on the expand state

--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -32,7 +32,7 @@ for (let p of params) {
 }
 
 let isStaticViewVisible = true;
-  
+
 /*
  * Set up aside menu by:
  * 1. populate content with headings sourced from given selectors;
@@ -94,16 +94,16 @@ new Vue({
 				};
 
 				results = filterResources(results, filterSettings);
-				
+
 				// Convert some post values to formats that can be displayed
 				if (results.length > 0) {
 					results = processResourcesDisplayResults(results);
 				}
-				
+
 				let tagsQuery = selectedTags.map(tag => "t_" + tag).join("=on&") +
 					selectedCategories.map(cat => "c_" + cat).join("=on&") +
 					selectedTypes.map(type => "t_" + type).join("=on&") + "=on";
-				
+
 				// Paginate search results
 				if (results.length > pageSize) {
 					pagination = createPagination(results, pageSize, pageInQuery, "/resources/?s=" + searchTerm + "&" + tagsQuery + "&page=:page");
@@ -113,7 +113,7 @@ new Vue({
 				vm.tags = response.data.tags.map(tag => ({ ...tag, checked: selectedTags.includes(tag.value)}));
 				vm.resourceCategories = response.data.resourceCategories.map(cat => ({ ...cat, checked: includesCaseInsensitive(selectedCategories, cat.categoryId)}));
 				vm.resourceTypes = response.data.resourceTypes.map(type => ({ ...type, checked: includesCaseInsensitive(selectedTypes, type.value)}));
-				
+
 				vm.selectedTags = response.data.tags.filter(tag => selectedTags.includes(tag.value));
 				vm.pagination = pagination;
 				vm.resultsToDisplay = pagination ? pagination.items : results;
@@ -156,6 +156,7 @@ for (let i = 0; i < expandButtons.length; i++) {
 	// Add event listener for expand buttons
 	expandButtons[i].addEventListener("click", (e) => {
 		e.preventDefault();
+		e.stopPropagation();
 		const currentExpandedValue = expandButtons[i].getAttribute("aria-expanded");
 		const expandedState = currentExpandedValue === "true" ? "false" : "true";
 		expandButtons[i].setAttribute("aria-expanded", expandedState);
@@ -171,6 +172,16 @@ for (let i = 0; i < expandButtons.length; i++) {
 
 		// Show/hide the expand svg
 		setExpandSVGState(expandButtons[i], expandedState);
+	});
+}
+
+// clicking a filter header opens/closes the corresponding filter. It behaves the same as clicking the corresponding
+// expand/collapse button.
+const filterHeaders = document.querySelectorAll(".filter .filter-header");
+
+for (let i = 0; i < filterHeaders.length; i++) {
+	filterHeaders[i].addEventListener("click", () => {
+		$(filterHeaders[i]).find(".filter-expand-button").click();
 	});
 }
 

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -9,6 +9,11 @@
 		grid-template-columns: 1fr;
 		row-gap: rem(32);
 
+		a:hover,
+		a:focus {
+			border-radius: rem(18);
+		}
+
 		.tile-item {
 			height: auto;
 			margin: 0;

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -68,6 +68,13 @@
 			background-color: initial;
 			border-bottom: rem(1) solid $grey-mid-light;
 			margin: 0;
+			padding: 0 rem(16);
+
+			&:focus,
+			&:hover {
+				border-radius: rem(8);
+				box-shadow: 0 0 rem(12) rgba(0, 0, 0, 0.6);
+			}
 
 			button {
 				margin-right: 0;

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -70,10 +70,8 @@
 			margin: 0;
 			padding: 0 rem(16);
 
-			&:focus,
 			&:hover {
-				border-radius: rem(8);
-				box-shadow: 0 0 rem(12) rgba(0, 0, 0, 0.6);
+				box-shadow: 0 rem(3) rem(2) rem(-2) rgba(0, 0, 0, 0.6);
 			}
 
 			button {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Display counter of total selected filter choices on each filter section header. This PR is based off https://github.com/BlueSlug/wecount.inclusivedesign.ca/pull/1, which should be reviewed and merged first.

## Steps to test

1. Go to resources page;
2. Open each filter section, select/unselect choice checkboxes; 
3. The total selected choices displayed on the header should adjust accordingly;
4. Perform a filtering so that the template is switched from the static to the dynamic;
5. Repeat step 2 and 3 to make sure the counting works fine with the dynamic template.

**Expected behavior:** 
See above.