### PR TITLE
fix: improve styling of the resources page when an uio theme is applied

### DIFF
--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -317,6 +317,11 @@
 		background: $bColor;
 	}
 
+	// Outlines for the topic tiles on the resources page
+	.topic-title {
+		border: 1px solid $fColor;
+	}
+
 	// UIO table of content
 	.flc-toc-tocContainer ul li::before {
 		color: $fColor;

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -145,6 +145,7 @@
 			margin: 0;
 
 			.tile-resource {
+				border-radius: rem(18);
 				padding: 0 rem(16) rem(8) rem(16);
 			}
 		}
@@ -206,6 +207,8 @@
 			}
 
 			button {
+				align-self: center;
+				height: rem(32);
 				margin-right: 0;
 				padding: 0;
 			}
@@ -271,6 +274,9 @@
 					border-radius: 0 0 $topic-title-border-radius $topic-title-border-radius;
 
 					.filter-checkbox + label {
+						// The same "border-radius" needs to be applied to the inner container for border
+						// curves displayed properly on the outer container
+						border-radius: 0 0 $topic-title-border-radius $topic-title-border-radius;
 						display: block;
 						font-size: rem(18);
 
@@ -324,7 +330,6 @@
 						align-items: start;
 						column-gap: 0;
 						grid-template-columns: initial;
-						// grid-template-rows: min-content min-content;
 						height: 100%;
 						padding: rem(16);
 						row-gap: 0;


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Improve the style of the resources page when an uio theme is applied

## Steps to test

1. Go to "Resources" page;
2. Apply a uio contrast theme;
3. The styles of topic tiles and resource item tiles should be improved.

**Expected behavior:** 
See above.