### PR TITLE
fix: improve the accessibility of expand/collapse buttons on the resources page

### DIFF
--- a/src/_includes/components/filter-resources.njk
+++ b/src/_includes/components/filter-resources.njk
@@ -4,7 +4,7 @@
   {# TODO: Dedupe this control #}
   <div class="filter-header">
     <h3>{{ topicsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">0</span>)</h3>
-    <button type="button" class="filter-expand-button" data-section="topics" aria-expanded="false" aria-label="expand">
+    <button type="button" class="filter-expand-button" data-section="topics" aria-expanded="false" aria-label="expand or collapse the topics filter">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
     </button>
@@ -48,7 +48,7 @@
   {# TODO: Dedupe this control #}
   <div class="filter-header">
     <h3>{{ tagsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">0</span>)</h3>
-    <button type="button" class="filter-expand-button" data-section="tags" aria-expanded="false" aria-label="expand">
+    <button type="button" class="filter-expand-button" data-section="tags" aria-expanded="false" aria-label="expand or collapse the tags filter">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
     </button>
@@ -70,7 +70,7 @@
   {# TODO: Dedupe this control #}
   <div class="filter-header">
     <h3>{{ typeFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">0</span>)</h3>
-    <button type="button" class="filter-expand-button" data-section="types" aria-expanded="false" aria-label="expand">
+    <button type="button" class="filter-expand-button" data-section="types" aria-expanded="false" aria-label="expand or collapse the media types filter">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
     </button>

--- a/src/_includes/components/filter.njk
+++ b/src/_includes/components/filter.njk
@@ -1,7 +1,7 @@
 <div class="filter">
   <div class="filter-header">
     <h2 class="h3">{{ filterTitle }}</h2>
-    <button type="button" class="filter-expand-button" aria-expanded="false" aria-label="expand">
+    <button type="button" class="filter-expand-button" aria-expanded="false" aria-label="expand or collapse search filters">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
     </button>

--- a/src/_includes/layouts/resources.njk
+++ b/src/_includes/layouts/resources.njk
@@ -110,7 +110,7 @@ pagination:
         {# TODO: Dedupe this control #}
         <div class="filter-header">
           <h3>{{ topicsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedCategories.length }}' }}</span>)</h3>
-          <button type="button" class="filter-expand-button" data-section="topics" aria-expanded="true" aria-label="expand">
+          <button type="button" class="filter-expand-button" data-section="topics" aria-expanded="true" aria-label="expand or collapse the topics filter">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
           </button>
@@ -140,7 +140,7 @@ pagination:
         {# TODO: Dedupe this control #}
         <div class="filter-header">
           <h3>{{ tagsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedTags.length }}' }}</span>)</h3>
-          <button type="button" class="filter-expand-button" data-section="tags" aria-expanded="true" aria-label="expand">
+          <button type="button" class="filter-expand-button" data-section="tags" aria-expanded="true" aria-label="expand or collapse the tags filter">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
           </button>
@@ -159,7 +159,7 @@ pagination:
         {# TODO: Dedupe this control #}
         <div class="filter-header">
           <h3>{{ typeFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedTypes.length }}' }}</span>)</h3>
-          <button type="button" class="filter-expand-button" data-section="types" aria-expanded="true" aria-label="expand">
+          <button type="button" class="filter-expand-button" data-section="types" aria-expanded="true" aria-label="expand or collapse the media types filter">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
           </button>

--- a/src/_includes/layouts/views.njk
+++ b/src/_includes/layouts/views.njk
@@ -73,7 +73,7 @@ pagination:
       <div class="filter">
         <div class="filter-header">
           <h2 class="h3">Search Filters</h2>
-          <button type="button" class="filter-expand-button" aria-expanded="true" aria-label="collapse">
+          <button type="button" class="filter-expand-button" aria-expanded="true" aria-label="expand or collapse search filters">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
           </button>

--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -212,7 +212,6 @@ for (let i = 0; i < expandButtons.length; i++) {
 		const currentExpandedValue = expandButtons[i].getAttribute("aria-expanded");
 		const expandedState = currentExpandedValue === "true" ? "false" : "true";
 		expandButtons[i].setAttribute("aria-expanded", expandedState);
-		expandButtons[i].setAttribute("aria-label", expandedState === "true" ? "collapse" : "expand");
 
 		// Open/close the appropriate filter
 		// Find the filter body by using its position relative to the button as well as the css selector

--- a/src/js/views-dynamic-handler.js
+++ b/src/js/views-dynamic-handler.js
@@ -133,7 +133,6 @@ for (let i = 0; i < expandButtons.length; i++) {
 		const currentExpandedValue = expandButtons[i].getAttribute("aria-expanded");
 		const expandedState = currentExpandedValue === "true" ? "false" : "true";
 		expandButtons[i].setAttribute("aria-expanded", expandedState);
-		expandButtons[i].setAttribute("aria-label", expandedState === "true" ? "collapse" : "expand");
 
 		// Open/close the filter
 		// Find the form filter by using its relative position with the button instead of a css selector is to work around


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Improve the accessibility of expand/collapse buttons on the resources page.

## Steps to test

1. Go to "Resources" page;
2. Use screen reader to compare the announcement for expand/collapse buttons;
3. Using the button for the topics filter as an example:
3.1  Before merging in this PR,  focusing on this button will announce "expand, collapsed, button". Click the button to toggle the state, the announcement will be "collapse, expanded, button".
3.2  After merging in this PR,  focusing on this button will announce "expand or collapse the topics filter, collapsed, button". Click the button to toggle the state, the announcement will be "expand or collapse the topics filter, expanded, button".

**Expected behavior:** 
See above.