### PR TITLE
fix: CMS preview panel no longer throws errors when creating new resources

### DIFF
--- a/src/_includes/layouts/resourceDetail.njk
+++ b/src/_includes/layouts/resourceDetail.njk
@@ -57,7 +57,9 @@
           <div><span class="feature-name">Source:</span> {{ source | safe }}</div>
 
           <svg><use xlink:href="#readability-on-detail" /></svg>
-          <div><span class="feature-name">Redability:</span> {{ readability | join(", ") | safe }}</div>
+          <div><span class="feature-name">Redability:</span>
+              {% if readability.length > 0 %}{{ readability | join(", ") | safe }}{% else %}N/A{% endif %}
+           </div>
 
           <svg><use xlink:href="#type" /></svg>
           <div><span class="feature-name">Type:</span> {{ type | safe }}</div>


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Fix the issue that CMS preview panel throws errors when creating new resources.

## Steps to test

1. Before merging in this pull request, go to admin page -> select "resources" on the left panel -> click "create a new resource";
2. The preview panel throws this error: `Template render error: (layouts/resourceDetail.njk) Template render error: (layouts/resourceDetail.njk) ...`

**Expected behavior:** 
With this pull request, the error should no longer occur. The preview panel should show proper layout with blank values.