### PR TITLE
fix: add back "apply filters" button

### DIFF
--- a/src/_includes/components/filter-resources-header.njk
+++ b/src/_includes/components/filter-resources-header.njk
@@ -1,5 +1,5 @@
   <div class="filter-header">
-    <h3>{{ filterTitle }}&nbsp;(<span class="filter-selected-choice-counter">0</span>)</h3>
+    <h3>{{ filterTitle }}</h3>
     <button type="button" class="filter-expand-button" data-section="{{ filterType | replace(" ", "") }}" aria-expanded="false" aria-label="expand or collapse the {{ filterType }} filter">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>

--- a/src/_includes/components/filter-resources.njk
+++ b/src/_includes/components/filter-resources.njk
@@ -71,6 +71,9 @@
   </div>
 
   <div class="filter-buttons">
+    <button class="apply-button" type="submit">
+      <svg><use xlink:href="#apply" /></svg><span>Apply Filters</span>
+    </button>
     <button class="reset-button" type="button">
       <svg><use xlink:href="#reset" /></svg><span>Reset Filters</span>
     </button>

--- a/src/_includes/layouts/resources.njk
+++ b/src/_includes/layouts/resources.njk
@@ -19,6 +19,9 @@ pagination:
     <symbol id="arrowdown" viewBox="0 0 39 24">
       {% include 'svg/arrowdown.svg' %}
     </symbol>
+    <symbol id="apply" viewBox="0 0 26 26" fill="none">
+      {% include 'svg/apply.svg' %}
+    </symbol>
     <symbol id="reset" viewBox="0 0 26 26" fill="none">
       {% include 'svg/reset.svg' %}
     </symbol>
@@ -186,6 +189,9 @@ pagination:
         </div>
 
         <div class="filter-buttons">
+          <button class="apply-button" type="submit">
+            <svg><use xlink:href="#apply" /></svg><span>Apply Filters</span>
+          </button>
           <button class="reset-button" type="button">
             <svg><use xlink:href="#reset" /></svg><span>Reset Filters</span>
           </button>

--- a/src/_includes/layouts/resources.njk
+++ b/src/_includes/layouts/resources.njk
@@ -111,7 +111,7 @@ pagination:
         {# Note: The dedupe is impossible for now because nunjucks syntax such as including a sub-template is not
         supported in a vue syntax template. This may become possible when eleventy supports Vue templates. #}
         <div class="filter-header">
-          <h3>{{ topicsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedCategories.length }}' }}</span>)</h3>
+          <h3>{{ topicsFilterTitle }}</h3>
           <button type="button" class="filter-expand-button" data-section="topics" aria-expanded="true" aria-label="expand or collapse the topics filter">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
@@ -144,7 +144,7 @@ pagination:
         {# Tag selections #}
         {# TODO: Dedupe this control #}
         <div class="filter-header">
-          <h3>{{ tagsFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedTags.length }}' }}</span>)</h3>
+          <h3>{{ tagsFilterTitle }}</h3>
           <button type="button" class="filter-expand-button" data-section="tags" aria-expanded="true" aria-label="expand or collapse the tags filter">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
@@ -166,7 +166,7 @@ pagination:
         {# Media Type selections #}
         {# TODO: Dedupe this control #}
         <div class="filter-header">
-          <h3>{{ typesFilterTitle }}&nbsp;(<span class="filter-selected-choice-counter">{{ '{{ selectedTypes.length }}' }}</span>)</h3>
+          <h3>{{ typesFilterTitle }}</h3>
           <button type="button" class="filter-expand-button" data-section="mediatypes" aria-expanded="true" aria-label="expand or collapse the media types filter">
             <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
             <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>

--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -80,6 +80,22 @@ function bindTopicTitleClick(viewSelector)
 }
 
 /*
+ * Bind change events for topic checkboxes. When a topic is checked or unchecked, reload the page immediately
+ * to show search results.
+ * @param {String} viewSelector - The selector of the static or the dynamic view template
+ */
+function bindTopicChange(viewSelector) {
+	// Clicking filter choices updates the corresponding counter
+	const topicCheckboxes = document.querySelectorAll(viewSelector + " .filter input[name^=c_]");
+
+	for (let i = 0; i < topicCheckboxes.length; i++) {
+		topicCheckboxes[i].addEventListener("change", (e) => {
+			e.target.closest("form").submit();
+		});
+	}
+}
+
+/*
  * Bind click handlers for filter section checkbox clear buttons.
  */
 function bindClearFilterButtonClick()
@@ -177,6 +193,7 @@ new Vue({
 		// Make sure change events for choice checkboxes in the dynamic view only bind once
 		if (this.numOfUpdated === 0) {
 			bindTopicTitleClick(".dynamic-view");
+			bindTopicChange(".dynamic-view");
 			bindClearFilterButtonClick();
 			this.numOfUpdated = 1;
 		}
@@ -190,6 +207,9 @@ if (isStaticViewVisible) {
 
 // Bind topic title checkbox selection in the static view template
 bindTopicTitleClick(".static-view");
+
+// Bind change events for topic checkboxes in the static view template
+bindTopicChange(".static-view");
 
 /*
  * Show/hide the corresponding arrow up and down buttons based on the expand state

--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -63,27 +63,6 @@ function searchResources(dataSet, searchTerm, resourceTags) {
 }
 
 /*
- * Bind change events for filter choice checkboxes. When a choice is checked or unchecked, update the selected
- * choices counter on the filter header.
- * @param {String} viewSelector - The selector of the static or the dynamic view template
- */
-function bindChoiceChange(viewSelector) {
-	// Clicking filter choices updates the corresponding counter
-	const filterCheckboxes = document.querySelectorAll(viewSelector + " .filter .filter-checkbox");
-
-	for (let i = 0; i < filterCheckboxes.length; i++) {
-		filterCheckboxes[i].addEventListener("change", (e) => {
-			const counterElm = $(e.target.closest(".filter-body")).prev().find(".filter-selected-choice-counter")[0];
-			const currentCount = parseInt(counterElm.innerText);
-			counterElm.innerText = e.target.checked ? currentCount + 1 : currentCount - 1;
-
-			// Submit the form to perform a filter when a choice is selected or unselected
-			e.target.closest("form").submit();
-		});
-	}
-}
-
-/*
  * Bind click handlers for topic checkbox titles. Clicking the text/icon for a given topic
  * is treated the same as if the user had clicked on the checkbox itself
  *
@@ -197,7 +176,6 @@ new Vue({
 
 		// Make sure change events for choice checkboxes in the dynamic view only bind once
 		if (this.numOfUpdated === 0) {
-			bindChoiceChange(".dynamic-view");
 			bindTopicTitleClick(".dynamic-view");
 			bindClearFilterButtonClick();
 			this.numOfUpdated = 1;
@@ -209,9 +187,6 @@ new Vue({
 if (isStaticViewVisible) {
 	setupAside("main article.static-view h1, main article.static-view h2");
 }
-
-// Bind change events for all choice checkboxes in the static view template
-bindChoiceChange(".static-view");
 
 // Bind topic title checkbox selection in the static view template
 bindTopicTitleClick(".static-view");


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

1. Selecting a topic will reload the page to show search results immediately;
2. For filter options in "tags" and "media types" sections, perform a filtering needs to select all options and click "apply filters" button.

This pull request is based off https://github.com/BlueSlug/wecount.inclusivedesign.ca/pull/11, which should be reviewed and merged first.

## Steps to test

1. Go to Resources page;
2. Select a topic, the page reloads to show search results;
3. Repeat step 2, topic selections trigger the search immediately;
4. Select options in "tags" and "media types" sections, nothing happens;
5. Hit "apply filters" button, the page reloads with the filtering results.

**Expected behavior:** 
See above.