### PR TITLE
fix: topics tiles should always be showing

### DIFF
--- a/src/_includes/components/filter-resources-header.njk
+++ b/src/_includes/components/filter-resources-header.njk
@@ -1,6 +1,6 @@
   <div class="filter-header">
     <h3>{{ filterTitle }}&nbsp;(<span class="filter-selected-choice-counter">0</span>)</h3>
-    <button type="button" class="filter-expand-button" data-section="{{ filterType | replace(" ", "") }}" aria-expanded="false" aria-label="expand or collapse the {{ filterType }} filter">
+    <button type="button" class="filter-expand-button" data-section="{{ filterType | replace(" ", "") }}" aria-expanded={% if filterType === "topics" %}"true"{% else %}"false"{% endif %} aria-label="expand or collapse the {{ filterType }} filter">
       <svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       <svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
     </button>

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -106,6 +106,11 @@
 			}
 		}
 
+		// override `display: hidden` defined in _news-and-views.scss
+		.filter-body[data-section="topics"] {
+			display: block;
+		}
+
 		.filter-body {
 			.filter-clear {
 				display: flex;


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Topics tiles should always be showing.

## Steps to test

1. Go to Resources page;
2. All topics tiles should show;
3. Perform search and filtering, topic tiles should stay showing.

**Expected behavior:** 
See above.