### PR TITLE
feat: add resource type into search columns

### DIFF
--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -39,6 +39,7 @@ for (let p of params) {
  * - learnTags
  * - abstract
  * - summary
+ * - type
  * - keywords
  *
  * @param {Array<Object>} dataSet - A set of Resource records upon which the search will be run
@@ -54,7 +55,8 @@ function searchResources(dataSet, searchTerm, resourceTags) {
 		const searchableContent = (oneRecord.title + " " +
 			oneRecord.learnTags.map(learnTag => resourceTags.find(tag => tag.value === learnTag).label).join(" ") + " " +
 			oneRecord.summary + " " +
-			oneRecord.keywords.join(" ") +
+			oneRecord.type + " " +
+			oneRecord.keywords.join(" ") + " " +
 			oneRecord.abstract).toLowerCase();
 		return searchableContent.match(escapeSpecialChars(searchTerm));
 	});

--- a/src/js/views-dynamic-handler.js
+++ b/src/js/views-dynamic-handler.js
@@ -1,6 +1,6 @@
 // For search functionality on the header.
 
-/* global Vue, axios, search, setupAside, createPagination, processDisplayResults, filter, slugify, generateAside, getSideMenuObserver, $ */
+/* global Vue, axios, search, createPagination, processDisplayResults, filter, slugify, getSideMenuObserver, $ */
 
 const pageSize = 10;
 const params = new URLSearchParams(window.location.search);
@@ -92,8 +92,7 @@ new Vue({
  * @param {String} selectors - A string of all selectors joined in comma. These selectors identifies headings
  * to be rendered in <aside>.
  */
-// eslint-disable-next-line
-generateAside = function (document, selectors) {
+function generateAside(document, selectors) {
 	const articleHeadings = [...document.querySelectorAll(selectors)];
 
 	if (articleHeadings.length) {
@@ -122,7 +121,7 @@ generateAside = function (document, selectors) {
 		tocNav.appendChild(tocUl);
 		toc.appendChild(tocNav);
 	}
-};
+}
 
 /*
  * Set up aside menu by:
@@ -130,8 +129,7 @@ generateAside = function (document, selectors) {
  * 2. Highlight the aside item at scrolling with the current active heading.
  * @param {String} selectors - A string of all selectors joined in comma. These selectors identifies headings
  */
-// eslint-disable-next-line
-setupAside = function (selectors) {
+function setupAside(selectors) {
 	// Populate content with headings sourced from given selectors;
 	generateAside(document, selectors);
 	// Highlight the scrolled-to content heading on the <aside> list.
@@ -139,7 +137,7 @@ setupAside = function (selectors) {
 		const contentHeaderObserver = getSideMenuObserver();
 		contentHeaderObserver.observe(section);
 	});
-};
+}
 
 // Set up the aside menu when pages using the static view are loaded
 if (isStaticViewVisible) {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Add resource type into search columns.

## Steps to test

1. Go to Resources page;
2. In the search box, enter a resource type such as "pdf";
3. Keep track of the number of matched results such as a value "A";
4. Apply filtering by selecting "PDF article" in "media types" filter section;
5. Keep track of the number of matched results such as a value "B";
6. A should be greater or equal than B.

**Expected behavior:** 
See above.