### PR TITLE
fix: fix an accessibility issue of having empty form labels

### DIFF
--- a/src/_includes/components/filter-resources.njk
+++ b/src/_includes/components/filter-resources.njk
@@ -29,7 +29,7 @@
           </div>
           <div class="topic-checkbox">
             <input class="filter-checkbox" aria-labelledby="{{ "title_" + categoryId }}" type="checkbox" id="{{ categoryId }}" name="{{ 'c_' + category.categoryId }}">
-            <label for="{{ categoryId }}"></label>
+            <span role="presentation"></span>
           </div>
         </li>
       {% endfor %}

--- a/src/_includes/layouts/resources.njk
+++ b/src/_includes/layouts/resources.njk
@@ -135,7 +135,7 @@ pagination:
                 </div>
                 <div class="topic-checkbox">
                   <input class="filter-checkbox" :aria-labelledby="'title_' + category.categoryId" type="checkbox" v-model="category.checked" :id="category.categoryId" :name="'c_' + category.categoryId">
-                  <label :for="category.categoryId"></label>
+                  <span role="presentation"></span>
                 </div>
               </li>
           </ul>

--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -63,18 +63,18 @@ function searchResources(dataSet, searchTerm, resourceTags) {
 }
 
 /*
- * Bind click handlers for topic checkbox titles. Clicking the text/icon for a given topic
- * is treated the same as if the user had clicked on the checkbox itself
+ * Bind click handlers for topic cards. Clicking anywhere on the topic tile is treated the same as if
+ * the user had clicked on the checkbox itself.
  *
  * @param {String} viewSelector - The selector of the static or the dynamic view template
  */
-function bindTopicTitleClick(viewSelector)
+function bindTopicCardClick(viewSelector)
 {
-	const topicTitles = document.querySelectorAll(viewSelector + " .filter .topic-title");
+	const topicCards = document.querySelectorAll(viewSelector + " .topic-choices li");
 
-	for (let i = 0; i < topicTitles.length; i++) {
-		topicTitles[i].addEventListener("click", () => {
-			$(topicTitles[i]).siblings(".topic-checkbox").find(".filter-checkbox").click();
+	for (let i = 0; i < topicCards.length; i++) {
+		topicCards[i].addEventListener("click", () => {
+			$(topicCards[i]).find("input").click();
 		});
 	}
 }
@@ -187,7 +187,7 @@ new Vue({
 	updated() {
 		// Make sure change events for choice checkboxes in the dynamic view only bind once
 		if (this.numOfUpdated === 0) {
-			bindTopicTitleClick(".dynamic-view");
+			bindTopicCardClick(".dynamic-view");
 			bindTopicChange(".dynamic-view");
 			bindClearFilterButtonClick();
 			this.numOfUpdated = 1;
@@ -196,7 +196,7 @@ new Vue({
 });
 
 // Bind topic title checkbox selection in the static view template
-bindTopicTitleClick(".static-view");
+bindTopicCardClick(".static-view");
 
 // Bind change events for topic checkboxes in the static view template
 bindTopicChange(".static-view");

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -73,12 +73,14 @@
 	.filter {
 		.filter-checkbox {
 			// Box
-			& + label::before {
+			& + label::before,
+			& + span::before {
 				outline: rem(1) solid $fColor;
 			}
 
 			// Checkmark
-			&:checked + label::after {
+			&:checked + label::after,
+			&:checked + span::after {
 				color: $bColor;
 			}
 		}
@@ -108,37 +110,47 @@
 	}
 
 	// Custom styles when "enhance inputs" is enabled
-	&.fl-input-enhanced .filter-checkbox + label::before {
+	&.fl-input-enhanced .filter-checkbox + label::before,
+	&.fl-input-enhanced .filter-checkbox + span::before {
 		outline: rem(3) double $fColor;
 	}
 
 	// Box checked
-	.filter .filter-checkbox:checked + label::before {
+	.filter .filter-checkbox:checked + label::before,
+	.filter .filter-checkbox:checked + span::before {
 		background: $fColor;
 	}
 
 	// Box focus
 	.filter .filter-checkbox:focus + label::before,
-	.filter .filter-checkbox:hover + label::before {
+	.filter .filter-checkbox:hover + label::before,
+	.filter .filter-checkbox:focus + span::before,
+	.filter .filter-checkbox:hover + span::before {
 		outline: rem(2.5) solid $fColor;
 	}
 
 	// Box focus when "enhance inputs" is enabled
 	&.fl-input-enhanced .filter-checkbox:focus + label::before,
-	&.fl-input-enhanced .filter-checkbox:hover + label::before {
+	&.fl-input-enhanced .filter-checkbox:hover + label::before,
+	&.fl-input-enhanced .filter-checkbox:focus + span::before,
+	&.fl-input-enhanced .filter-checkbox:hover + span::before {
 		border: rem(2.5) solid $fColor;
 		outline: rem(3.5) double $fColor;
 	}
 
 	// Box checked and focus/hover
 	.filter .filter-checkbox:checked:focus + label::before,
-	.filter .filter-checkbox:checked:hover + label::before {
+	.filter .filter-checkbox:checked:hover + label::before,
+	.filter .filter-checkbox:checked:focus + span::before,
+	.filter .filter-checkbox:checked:hover + span::before {
 		outline: rem(3) double $fColor;
 	}
 
 	// Box checked and focus/hover when "enhance inputs" is enabled
 	&.fl-input-enhanced .filter-checkbox:checked:focus + label::before,
-	&.fl-input-enhanced .filter-checkbox:checked:hover + label::before {
+	&.fl-input-enhanced .filter-checkbox:checked:hover + label::before,
+	&.fl-input-enhanced .filter-checkbox:checked:focus + span::before,
+	&.fl-input-enhanced .filter-checkbox:checked:hover + span::before {
 		border: rem(1) solid $bColor;
 		box-shadow: 0 0 0 rem(1) $fColor inset;
 		outline: rem(3) double $fColor;

--- a/src/scss/components/_filter.scss
+++ b/src/scss/components/_filter.scss
@@ -39,14 +39,16 @@
 		opacity: 0; // hide it
 		position: absolute; // take it out of document flow
 
-		& + label {
+		& + label,
+		& + span {
 			cursor: pointer;
 			padding: 0;
 			position: relative;
 		}
 
 		// Box
-		& + label::before {
+		& + label::before,
+		& + span::before {
 			content: '';
 			display: inline-block;
 			height: rem(20);
@@ -57,7 +59,8 @@
 		}
 
 		// Checkmark
-		&:checked + label::after {
+		&:checked + label::after,
+		&:checked + span::after {
 			color: $white;
 			content: '\2713';
 			font-size: rem(18);
@@ -156,37 +159,47 @@
 
 // Custom styles when "enhance inputs" is enabled
 // Custom checkbox
-.fl-input-enhanced .filter-checkbox + label::before {
+.fl-input-enhanced .filter-checkbox + label::before,
+.fl-input-enhanced .filter-checkbox + span::before {
 	outline: rem(3) double $blue-alt-light;
 }
 
 // Box checked
-.filter .filter-checkbox:checked + label::before {
+.filter .filter-checkbox:checked + label::before,
+.filter .filter-checkbox:checked + span::before {
 	background: $blue-alt-light;
 }
 
 // Box focus
 .filter .filter-checkbox:focus + label::before,
-.filter .filter-checkbox:hover + label::before {
+.filter .filter-checkbox:hover + label::before,
+.filter .filter-checkbox:focus + span::before,
+.filter .filter-checkbox:hover + span::before {
 	outline: rem(2.5) solid $blue-alt-light;
 }
 
 // Box focus when "enhance inputs" is enabled
 .fl-input-enhanced .filter-checkbox:focus + label::before,
-.fl-input-enhanced .filter-checkbox:hover + label::before {
+.fl-input-enhanced .filter-checkbox:hover + label::before,
+.fl-input-enhanced .filter-checkbox:focus + span::before,
+.fl-input-enhanced .filter-checkbox:hover + span::before {
 	border: rem(2.5) solid $blue-alt-light;
 	outline: rem(3.5) double $blue-alt-light;
 }
 
 // Box checked and focus/hover
 .filter .filter-checkbox:checked:focus + label::before,
-.filter .filter-checkbox:checked:hover + label::before {
+.filter .filter-checkbox:checked:hover + label::before,
+.filter .filter-checkbox:checked:focus + span::before,
+.filter .filter-checkbox:checked:hover + span::before {
 	outline: rem(3) double $blue-alt-light;
 }
 
 // Box checked and focus/hover
 .fl-input-enhanced .filter-checkbox:checked:focus + label::before,
-.fl-input-enhanced .filter-checkbox:checked:hover + label::before {
+.fl-input-enhanced .filter-checkbox:checked:hover + label::before,
+.fl-input-enhanced .filter-checkbox:checked:focus + span::before,
+.fl-input-enhanced .filter-checkbox:checked:hover + span::before {
 	border: rem(1) solid $white;
 	box-shadow: 0 0 0 rem(1) $blue-alt-light inset;
 	outline: rem(3) double $blue-alt-light;

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -191,7 +191,13 @@
 					border: 1px solid $blue-alt-light;
 					border-radius: 0 0 $topic-title-border-radius $topic-title-border-radius;
 
-					.filter-checkbox + label {
+					// when the topic checkbox bar gains the hover, apply the hover style to the checkbox
+					&:hover span::before {
+						outline: rem(2.5) solid $blue-alt-light;
+					}
+
+					.filter-checkbox + label,
+					.filter-checkbox + span {
 						// The same "border-radius" needs to be applied to the inner container for border
 						// curves displayed properly on the outer container
 						border-radius: 0 0 $topic-title-border-radius $topic-title-border-radius;
@@ -204,7 +210,8 @@
 						}
 					}
 
-					.filter-checkbox:checked + label::after {
+					.filter-checkbox:checked + label::after,
+					.filter-checkbox:checked + span::after {
 						left: 50%;
 						margin-left: rem(-7);
 					}

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -163,6 +163,11 @@
 				min-width: 100%;
 				text-align: center;
 
+				// when the topic card gains the hover, apply the hover style to the checkbox
+				&:hover .topic-checkbox span::before {
+					outline: rem(2.5) solid $blue-alt-light;
+				}
+
 				svg {
 					height: rem(80);
 					width: 100%;
@@ -190,11 +195,6 @@
 					background: $white;
 					border: 1px solid $blue-alt-light;
 					border-radius: 0 0 $topic-title-border-radius $topic-title-border-radius;
-
-					// when the topic checkbox bar gains the hover, apply the hover style to the checkbox
-					&:hover span::before {
-						outline: rem(2.5) solid $blue-alt-light;
-					}
 
 					.filter-checkbox + label,
 					.filter-checkbox + span {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Fix an accessibility issue of having empty form labels on topic cards.

To reproduce the issue: when using WAVE to check accessibility, labels used for styling topic checkboxes report error: empty form labels. It's because these labels are only used for styling purpose without having any content. The fix is to replace "label" elements with "span" elements. 

## Steps to test

1. Go to Resources page;
2. Use WAVE to check accessibility, no error should be reported;
3. Test the functionality of topic checkboxes. Everything should work the same as before.

**Expected behavior:**
See above.