### PR TITLE
fix: fix broken pagination URLs

### DIFF
--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -163,9 +163,12 @@ new Vue({
 					results = processResourcesDisplayResults(results);
 				}
 
-				let filterQuery = selectedCategories.map(cat => "c_" + cat).join("=on&") + "&" +
-					selectedTags.map(tag => "t_" + tag).join("=on&") + "&" +
-					selectedTypes.map(type => "m_" + type).join("=on&") + "=on";
+				// the "filter" call is to ignore empty query strings
+				let filterQuery = [
+					selectedCategories.map(cat => "c_" + cat + "=on").join("&"),
+					selectedTags.map(tag => "t_" + tag + "=on").join("&"),
+					selectedTypes.map(type => "m_" + type + "=on").join("&")
+				].filter(query => query).join("&");
 
 				// Paginate search results
 				if (results.length > pageSize) {

--- a/src/js/resources-dynamic-handler.js
+++ b/src/js/resources-dynamic-handler.js
@@ -163,13 +163,13 @@ new Vue({
 					results = processResourcesDisplayResults(results);
 				}
 
-				let tagsQuery = selectedTags.map(tag => "t_" + tag).join("=on&") +
-					selectedCategories.map(cat => "c_" + cat).join("=on&") +
-					selectedTypes.map(type => "t_" + type).join("=on&") + "=on";
+				let filterQuery = selectedCategories.map(cat => "c_" + cat).join("=on&") + "&" +
+					selectedTags.map(tag => "t_" + tag).join("=on&") + "&" +
+					selectedTypes.map(type => "m_" + type).join("=on&") + "=on";
 
 				// Paginate search results
 				if (results.length > pageSize) {
-					pagination = createPagination(results, pageSize, pageInQuery, "/resources/?s=" + searchTerm + "&" + tagsQuery + "&page=:page");
+					pagination = createPagination(results, pageSize, pageInQuery, "/resources/?s=" + searchTerm + "&" + filterQuery + "&page=:page");
 				}
 
 				// add checked states for tags, categories and media types


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Fix broken pagination URLs

## Steps to test

1. Go to resources page;
2. Select some topics, tags and media types -> click "apply filters";
3. Make sure to produce more than 10 search results so the pagination bar contains more than one page;
4. Click page numbers, previous page, next page on the pagination;
5. Make sure proper set of search results shown for each page.

**Expected behavior:**
See above.