### PR TITLE
fix: allow the less than sign (<) in user input fields

### DIFF
--- a/src/_includes/components/tile-item-resource.njk
+++ b/src/_includes/components/tile-item-resource.njk
@@ -1,7 +1,7 @@
 <a href="{{ tileURL }}">
   <div class="tile-item">
     <div class="tile-resource">
-      <h2 class="h3">{{ title | safe }}</h2>
+      <h2 class="h3">{{ title | replace("<", "&lt;") | safe }}</h2>
       {# TODO: localize these items/labels #}
       <div class="info">
         <svg aria-hidden="true"><use xlink:href="#media-type" /></svg>

--- a/src/_includes/layouts/resourceDetail.njk
+++ b/src/_includes/layouts/resourceDetail.njk
@@ -47,7 +47,7 @@
 <article class="resource-detail">
   <h1>{{ title | replace("<", "&lt;") | safe }}</h1>
   <div class="api-content">
-      {{ content | replace("<", "&lt;") | safe }}
+      {{ content | safe }}
 
       <div class="features">
           <svg><use xlink:href="#focus" /></svg>

--- a/src/_includes/layouts/resourceDetail.njk
+++ b/src/_includes/layouts/resourceDetail.njk
@@ -45,16 +45,16 @@
 </svg>
 
 <article class="resource-detail">
-  <h1>{{ title | safe }}</h1>
+  <h1>{{ title | replace("<", "&lt;") | safe }}</h1>
   <div class="api-content">
-      {{ content | safe }}
+      {{ content | replace("<", "&lt;") | safe }}
 
       <div class="features">
           <svg><use xlink:href="#focus" /></svg>
           <div><span class="feature-name">Focus:</span> {{ focus | safe }}</div>
 
           <svg><use xlink:href="#source" /></svg>
-          <div><span class="feature-name">Source:</span> {{ source | safe }}</div>
+          <div><span class="feature-name">Source:</span> {{ source | replace("<", "&lt;") | safe }}</div>
 
           <svg><use xlink:href="#readability-on-detail" /></svg>
           <div><span class="feature-name">Redability:</span>
@@ -112,7 +112,7 @@
 
           <svg><use xlink:href="#summary" /></svg>
           <div><span class="feature-name">Summary:</span>
-              {% if summary and summary !== "" %}{{ summary | safe }}{% else %}N/A{% endif %}
+              {% if summary and summary !== "" %}{{ summary | replace("<", "&lt;") | safe }}{% else %}N/A{% endif %}
           </div>
       </div>
   </div>

--- a/src/collections/resources/less-than-one-shot-learning-learning-n-classes-from-mlessn-samples-pdf-article.md
+++ b/src/collections/resources/less-than-one-shot-learning-learning-n-classes-from-mlessn-samples-pdf-article.md
@@ -1,5 +1,5 @@
 ---
-title: "\"Less Than One\"-Shot Learning: Learning N Classes From M&lt;N Samples"
+title: "\"Less Than One\"-Shot Learning: Learning N Classes From M<N Samples"
 focus: "Methods or Design"
 source: "University of Waterloo"
 readability: ["Expert"]


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Allow the less than sign (<) in user input fields. This PR is to fix the problem mentioned in [this comment](https://github.com/inclusive-design/wecount.inclusivedesign.ca/pull/720#discussion_r755548359).

## Steps to test

1. Use admin interface to create a new resource that all user input fields contain "<";
2. The rebuild should complete successfully;
3. Access this resource on both the resource page and the resource detail page;
4. The < should show up correctly.

**Expected behavior:** 
See above.